### PR TITLE
docs(arquitetura): adiciona MCP Server e migra diagrama para Mermaid

### DIFF
--- a/docs/planejamento/arquitetura.md
+++ b/docs/planejamento/arquitetura.md
@@ -62,9 +62,47 @@ A partir do semestre 2026.1 padronizamos o ferramental de runtime e pacotes em t
 
 - **Github Action** Action customizada do Github que permite realizar a análise de um certo repositorio. Esta aplicação é responsável por se comunicar com o serviço `Service` e fornecer todos os dados necessários para a aplicação web.
 
+- **MCP Server** Servidor que expõe os dados e operações do MeasureSoftGram via [Model Context Protocol](https://modelcontextprotocol.io), permitindo que clientes de IA (ex.: Claude Desktop, Claude Code) consultem qualidade de software diretamente em fluxos conversacionais. Reside em repositório separado, comunica-se com o `Service` via API HTTP e não altera o esquema do banco de dados nem depende do `Frontend Web`.
+
 ## Diagrama Arquitetural
 
-![Diagrama Arquitetural](../assets/images/diagrama_arquitetura.png)
+> **Nota (R1 2026.1):** o diagrama abaixo é mantido em [Mermaid](https://mermaid.js.org) — texto puro versionado neste repositório, renderizado nativamente pelo MkDocs. Substitui o PNG anterior, que não possuía fonte editável versionada e exigia recriação manual em ferramenta externa a cada mudança arquitetural. Para editar, basta abrir um PR alterando o bloco abaixo.
+
+```mermaid
+flowchart TB
+    subgraph Cliente["Clientes"]
+        FE["💻 Frontend Web<br/>(React + Next.js)"]
+        AI["🧠 Cliente de IA<br/>(Claude Desktop / Code)"]
+    end
+
+    subgraph Container["Ambiente containerizado"]
+        direction TB
+        RP["🐳 Reverse Proxy<br/>(nginx)"]
+        SVC["🐳 Service<br/>(Django + PostgreSQL 18)"]
+        RP <--> SVC
+    end
+
+    CLI["⌨️ CLI<br/>(Python 3.12)"]
+    Core["⚙️ Core<br/>(Python 3.12)"]
+    Parser["📊 Parser<br/>(Python + pandas)"]
+    Action["🤖 GitHub Action<br/>(TypeScript)"]
+    MCP["🔌 MCP Server<br/>(Python)"]
+
+    FE <-->|HTTPS| RP
+    AI <-->|MCP| MCP
+    MCP <-->|HTTP| SVC
+    CLI <-->|HTTP| SVC
+    Core <-->|HTTP| SVC
+    Parser <-->|HTTP| SVC
+    Action <-->|HTTPS| SVC
+
+    classDef cliente fill:#e8f8e8,stroke:#2a8c3a,stroke-dasharray:5 5
+    classDef container fill:#f0e8f8,stroke:#6a3a8c,stroke-dasharray:5 5
+    classDef novo fill:#fff4d6,stroke:#b07c00,stroke-width:2px
+    class Cliente cliente
+    class Container container
+    class MCP,AI novo
+```
 
 ## Diagrama de Implantação
 Um diagrama de implantação especifica os construtos que podem ser usados para definir a arquitetura de execução de sistemas e a atribuição de artefatos de software aos elementos do sistema.Para descrever um site, por exemplo, um diagrama de implantação mostraria quais componentes de hardware ("nós") existem (por exemplo, um servidor web, um servidor de aplicação e um servidor de banco de dados), quais componentes de software ("artefatos") rodam em cada nó (por exemplo, aplicação web, banco de dados) e como as diferentes peças estão conectadas (por exemplo, HTTP, GRPC).
@@ -178,3 +216,4 @@ Os nós de dispositivo são recursos físicos de computação com memória de pr
 |13/09/2024| Christian Siqueira | Adicioanndo diagrama de implantação |1.2|
 |13/09/2024| Christian Siqueira | Atualizando o diagrama de arquitetura|1.3|
 |27/04/2026| Giovanni A. C. Giampauli | Revisão R1 2026.1: registra decisões de stack do semestre — PostgreSQL 18, uv (Python), pnpm (JS), Python 3.12, Node 20 LTS, versões pinadas no Docker, Compose v2 com `compose watch`. Diagramas permanecem vigentes (sem mudança topológica). |1.4|
+|03/05/2026| Giovanni A. C. Giampauli | Adiciona o **MCP Server** na lista de serviços e no diagrama arquitetural, refletindo a integração com clientes de IA via Model Context Protocol — atende ao pedido do cliente Hilmer durante a R1 de documentar o microserviço de integração com IA. **Substitui o diagrama arquitetural em PNG por bloco Mermaid** versionado em texto: o PNG anterior não tinha fonte editável no repositório, dificultando atualizações colaborativas; com Mermaid, o diagrama vive como texto neste markdown, qualquer integrante pode propor mudanças via PR e o diff fica explícito. Diagrama de Implantação e Diagrama de Pacotes do MCP ficam pendentes para a R2 (gap visual sinalizado). |1.5|


### PR DESCRIPTION
## O que muda

Em `docs/planejamento/arquitetura.md`:

1. **Lista de Serviços** — adiciona o **MCP Server** como microserviço, descrevendo o papel dele na integração com clientes de IA (Claude Desktop, Claude Code) via [Model Context Protocol](https://modelcontextprotocol.io). Reside em repositório separado, comunica-se com `Service` via HTTP, **não altera o esquema do banco** nem depende do `Frontend Web`.

2. **Diagrama Arquitetural — PNG → Mermaid.** Substitui `assets/images/diagrama_arquitetura.png` por um bloco Mermaid versionado em texto no próprio markdown. Inclui o MCP Server e o cliente de IA no diagrama. Renderização nativa pelo MkDocs (já configurado: `pymdownx.superfences` + plugin `mermaid2`).

3. **Versionamento** — entrada `1.5` no histórico do documento explicando as duas mudanças e o motivo da migração PNG → Mermaid.

## Por que migrar pra Mermaid

O PNG anterior **não tinha fonte editável versionada** neste repositório (não há `.drawio`/`.puml`/`.xml` correspondente em `docs/assets/`). Pra atualizar a arquitetura era preciso recriar o diagrama em ferramenta externa e substituir o binário — fluxo opaco, sem diff, sem rastreabilidade colaborativa.

Em Mermaid o diagrama vive como texto no próprio markdown:
- Qualquer integrante edita via PR;
- O diff aparece explícito;
- Versionado junto com a documentação que o referencia;
- Renderização nativa no MkDocs, sem ferramenta externa.

**Tradeoff conhecido:** o visual do Mermaid `flowchart` é mais simples que o PNG anterior. Ganhamos em manutenibilidade e colaboração, perdemos em refinamento estético. Para R2 vale considerar adoção de [D2](https://d2lang.com) ou `.drawio` versionado se a estética for ponto de retorno do cliente.

## Alinhamento com feedback do Hilmer (R1)

Um dos pontos do feedback do prof na R1 foi que o cliente sentiu que recebia funcionalidades sem entender o sistema. Documentar formalmente o **MCP Server** na arquitetura — antes da Minor — atende diretamente esse ponto: o cliente terá visibilidade do microserviço de IA antes de receber a funcionalidade.

## Pendências (R2)

- [ ] **Diagrama de Implantação** — ainda em PNG, sem MCP. Sem fonte editável no repo. Migrar pra Mermaid ou ferramenta versionável na R2.
- [ ] **Diagrama de Pacotes do MCP** — só faz sentido depois que o repositório do MCP Server existir e tiver pacotes definidos.
- [ ] **DER (`diagrama_banco.png`)** — Pierre/Danilo já estão refazendo por outros motivos; MCP não impacta o banco, então sem ação adicional aqui.

## Como revisar

Renderização local:

```bash
mkdocs serve
# abre http://127.0.0.1:8000/planejamento/arquitetura/
```

Ou direto no GitHub: o diff do PR já mostra o bloco `mermaid` (renderizado pelo próprio GitHub no preview do markdown).