### PR TITLE
docs: Guia de GitHub Token e adiciona configuração OAuth App

### DIFF
--- a/docs/onboarding/actionLocal.md
+++ b/docs/onboarding/actionLocal.md
@@ -81,9 +81,9 @@ GITHUB_TOKEN=ghp_SEU_TOKEN_AQUI
 
 ### Configurando o OAuth App do GitHub (autenticação web)
 
-Para habilitar o login via GitHub na interface web do MeasureSoftGram, é necessário criar um **OAuth App** na sua conta do GitHub e configurar as credenciais nos serviços.
+Para habilitar o login via GitHub na interface web do MeasureSoftGram, é necessário criar um **OAuth App** e configurar as credenciais nos serviços. O app pode ser criado de duas formas: via conta pessoal ou via organização. Para ambientes de desenvolvimento individual, a conta pessoal é suficiente. Para ambientes compartilhados ou corporativos, recomenda-se criar pelo nível da organização.
 
-#### 1. Criar o OAuth App
+#### Opção A — OAuth App via conta pessoal
 
 1. Acesse **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
    (ou diretamente em `https://github.com/settings/applications/new`)
@@ -104,7 +104,44 @@ Para habilitar o login via GitHub na interface web do MeasureSoftGram, é necess
 
 > **Atenção:** o client secret é exibido apenas uma vez. Guarde-o em local seguro.
 
-#### 2. Configurar as credenciais no Service
+---
+
+#### Opção B — OAuth App via organização (recomendado para times)
+
+Criar o OAuth App pelo nível da organização garante que as credenciais pertençam ao time e não a um membro individual, evitando problemas caso alguém saia da organização.
+
+> **Pré-requisito:** você precisa ter permissão de **Owner** ou **Admin** na organização do GitHub.
+
+1. Acesse a página da organização no GitHub e vá em:
+   **Organization Settings → Developer settings → OAuth Apps → New OAuth App**
+   
+   A URL segue o padrão:
+   ```
+   https://github.com/organizations/<nome-da-org>/settings/applications/new
+   ```
+
+2. Preencha os campos:
+
+   | Campo | Valor |
+   |---|---|
+   | Application name | `MeasureSoftGram` |
+   | Homepage URL | `http://localhost:3000` |
+   | Authorization callback URL | `http://127.0.0.1:3000` |
+
+3. Clique em **Register application**
+
+4. Na página do app criado:
+   - Copie o **Client ID**
+   - Clique em **Generate a new client secret** e copie o secret
+
+5. Para que membros da organização consigam autenticar via esse OAuth App, pode ser necessário solicitar aprovação da organização. Caso apareça a mensagem **"Organization access"** durante o login, o owner da org precisa aprovar em:
+   **Organization Settings → OAuth Application Policy**
+
+> **Atenção:** o client secret é exibido apenas uma vez. Guarde-o em local seguro ou utilize um gerenciador de segredos (ex: GitHub Secrets, Vault).
+
+---
+
+#### Configurar as credenciais no Service
 
 Edite `Service/env-vars/.service.env`:
 
@@ -113,7 +150,7 @@ GITHUB_CLIENT_ID=<seu_client_id>
 GITHUB_SECRET=<seu_client_secret>
 ```
 
-#### 3. Configurar o Client ID no Front
+#### Configurar o Client ID no Front
 
 Adicione ao arquivo `Front/.env`:
 
@@ -123,7 +160,7 @@ GITHUB_CLIENT_ID=<seu_client_id>
 
 > O `GITHUB_CLIENT_ID` no Front é uma variável de **build-time** — é embutida na imagem durante o build. Sempre que alterar esse valor, execute `docker compose up --build` no diretório `Front/`.
 
-#### 4. Reiniciar os serviços
+#### Reiniciar os serviços
 
 **Backend:**
 ```bash

--- a/docs/onboarding/actionLocal.md
+++ b/docs/onboarding/actionLocal.md
@@ -52,7 +52,93 @@ MSGRAM_SERVICE_HOST=http://localhost:8080
 
 ### Obtendo o GitHub Token
 
-Crie um **Personal Access Token (PAT)** seguindo as instruções oficiais na [documentação do GitHub](https://docs.github.com/pt/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+O `GITHUB_TOKEN` utilizado na pipeline é um **Personal Access Token (PAT)** gerado na sua conta do GitHub. Siga os passos abaixo:
+
+1. Acesse **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
+   (ou diretamente em `https://github.com/settings/tokens`)
+
+2. Clique em **Generate new token → Generate new token (classic)**
+
+3. Preencha os campos:
+   - **Note:** `MeasureSoftGram Local` (ou qualquer nome identificador)
+   - **Expiration:** escolha o período desejado
+   - **Scopes:** selecione ao menos:
+     - `repo` — acesso completo a repositórios
+     - `read:org` — leitura de dados da organização
+     - `user` — leitura de dados do perfil
+
+4. Clique em **Generate token** e **copie o token gerado imediatamente** — ele não será exibido novamente.
+
+5. Cole o valor no arquivo `env-vars/.action.env`:
+
+```dotenv
+GITHUB_TOKEN=ghp_SEU_TOKEN_AQUI
+```
+
+> **Dica:** caso o token expire, basta gerar um novo seguindo os mesmos passos e atualizar o arquivo de variáveis de ambiente.
+
+---
+
+### Configurando o OAuth App do GitHub (autenticação web)
+
+Para habilitar o login via GitHub na interface web do MeasureSoftGram, é necessário criar um **OAuth App** na sua conta do GitHub e configurar as credenciais nos serviços.
+
+#### 1. Criar o OAuth App
+
+1. Acesse **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
+   (ou diretamente em `https://github.com/settings/applications/new`)
+
+2. Preencha os campos:
+
+   | Campo | Valor |
+   |---|---|
+   | Application name | `MeasureSoftGram Local` |
+   | Homepage URL | `http://localhost:3000` |
+   | Authorization callback URL | `http://127.0.0.1:3000` |
+
+3. Clique em **Register application**
+
+4. Na página do app criado:
+   - Copie o **Client ID**
+   - Clique em **Generate a new client secret** e copie o secret
+
+> **Atenção:** o client secret é exibido apenas uma vez. Guarde-o em local seguro.
+
+#### 2. Configurar as credenciais no Service
+
+Edite `Service/env-vars/.service.env`:
+
+```dotenv
+GITHUB_CLIENT_ID=<seu_client_id>
+GITHUB_SECRET=<seu_client_secret>
+```
+
+#### 3. Configurar o Client ID no Front
+
+Adicione ao arquivo `Front/.env`:
+
+```dotenv
+GITHUB_CLIENT_ID=<seu_client_id>
+```
+
+> O `GITHUB_CLIENT_ID` no Front é uma variável de **build-time** — é embutida na imagem durante o build. Sempre que alterar esse valor, execute `docker compose up --build` no diretório `Front/`.
+
+#### 4. Reiniciar os serviços
+
+**Backend:**
+```bash
+cd Service
+docker compose down
+docker compose up
+```
+
+**Frontend:**
+```bash
+cd Front
+docker compose up --build
+```
+
+Acesse `http://localhost:3000` e clique em **LOGIN COM GITHUB** para validar o fluxo.
 
 ---
 
@@ -162,6 +248,7 @@ https://docs.google.com/forms/d/e/1FAIpQLSczE17X6JWlXLzCLAfMmKi0jpMGQuWmUxXdaS6d
 | 1.0    | 12/04/2026 | Criação do documento            | [João Antonio](https://github.com/i-JSS) |     [Nicollas Gabriel](https://github.com/Nicollaxs)    |
 | 1.1     | 13/04/2026 | Adicona JSON no cadastro de goal | [João Antonio](https://github.com/i-JSS)                                         |      [Nicollas Gabriel](https://github.com/Nicollaxs)    |
 | 1.2     | 13/04/2026 | Adiciona formulário de entrega da release | [Nicollas Gabriel](https://github.com/Nicollaxs) |  |
+| 1.3     | 16/06/2026 | Expande guia de obtenção do GitHub Token e adiciona configuração do OAuth App | [Nicollas Gabriel](https://github.com/Nicollaxs) |  |
 
 
 


### PR DESCRIPTION
…(#65)

## Descrição das alterações

Guia de como gerar um token no github e adicionar a configuração OAuth App

## Nome e número da issue que resolve 
#65

## Critérios de aceitação
 - [ ] Realizar o spike técnico (validação prática do fluxo em ambiente de homologação).
 - [ ]  Coletar os URLs de callback padrão do Auth0 necessários para a etapa do GitHub.
 - [ ] Redigir a estrutura inicial do Markdown.
 - [ ] Submeter o arquivo de documentação para revisão por pares (Pull Request de Doc).

